### PR TITLE
Reuse existing PR when available.

### DIFF
--- a/bin/clu
+++ b/bin/clu
@@ -10,13 +10,27 @@ if ( file_exists( $path = __DIR__ . '/../vendor/autoload.php' )
 	throw new \Exception('Could not locate autoload.php');
 }
 
+\CLU\Checker::check_executables();
+
 $repo_url = ! empty( $argv[1] ) ? $argv[1] : '';
 if ( getenv( 'CLU_GIT_URL' ) ) {
 	$repo_url = getenv( 'CLU_GIT_URL' );
 }
+$repo_local_working_copy = false;
+if ( ! $repo_url ) {
+  $repo_local_working_copy = getcwd();
+  $first_line_of_output = exec('git config --get remote.origin.url', $outputLines, $status);
+  if ( ! $status ) {
+    $repo_url = $first_line_of_output;
+  }
+}
 if ( ! $repo_url ) {
 	CLU\Logger::error( 'Git URL must be provided as first argument or with CLU_GIT_URL' );
 }
+if ( ! $repo_local_working_copy ) {
+  $cloner = new CLU\Cloner();
+  $repo_local_working_copy = $cloner->cloneRepo( $repo_url );
+}
 
 $runner = new CLU\Runner( $repo_url );
-$runner->start();
+$runner->start( $repo_local_working_copy );

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,14 @@
         "psr-4": {"CLU\\": "src/"}
     },
     "scripts": {
+        "lint": "find src -name '*.php' -exec php -l {} \\;",
         "cs": "phpcs -n src",
         "cbf": "phpcbf -n src",
         "unit": "echo tbd: phpunit --colors=always",
         "test": [
             "@unit",
-            "@cs"
+            "@cs",
+            "@lint"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,22 @@
         }
     ],
     "require": {},
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^2.7"
+    },
     "bin": [
         "bin/clu"
     ],
     "autoload": {
         "psr-4": {"CLU\\": "src/"}
+    },
+    "scripts": {
+        "cs": "phpcs -n src",
+        "cbf": "phpcbf -n src",
+        "unit": "echo tbd: phpunit --colors=always",
+        "test": [
+            "@unit",
+            "@cs"
+        ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,96 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "e676cc9165c24c66eed81b1e39c2e356",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-05-22T02:43:20+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+  <description>Enforce TABS instead of SPACES for indentation.</description>
+
+  <file>bin/clu</file>
+  <file>src</file>
+
+  <!-- At the moment, we do not define a default coding standard; we only enforce TABS instead of SPACES -->
+
+  <!-- TABS instead of SPACES. See: https://github.com/squizlabs/PHP_CodeSniffer/issues/467 -->
+  <arg name="tab-width" value="4" />
+  <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+
+  <rule ref="Generic.WhiteSpace.ScopeIndent">
+    <properties>
+      <property name="tabIndent" value="true"/>
+    </properties>
+  </rule>
+
+</ruleset>

--- a/src/Checker.php
+++ b/src/Checker.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CLU;
+
+class Checker {
+
+  /**
+   * Check that Git, Composer, and Hub are available on the filesystem.
+   */
+  public static function check_executables() {
+    $execs = array( 'git', 'composer', 'hub' );
+    foreach( $execs as $exec ) {
+      exec( 'type ' . escapeshellarg( $exec ), $_, $return_code );
+      if ( 0 !== $return_code ) {
+        Logger::error( "Missing {$exec} on the system." );
+      }
+    }
+    Logger::info( 'Found required executables on system: ' . implode( ', ', $execs ) );
+  }
+
+}

--- a/src/Checker.php
+++ b/src/Checker.php
@@ -4,18 +4,18 @@ namespace CLU;
 
 class Checker {
 
-  /**
+	/**
    * Check that Git, Composer, and Hub are available on the filesystem.
    */
-  public static function check_executables() {
-    $execs = array( 'git', 'composer', 'hub' );
-    foreach( $execs as $exec ) {
-      exec( 'type ' . escapeshellarg( $exec ), $_, $return_code );
-      if ( 0 !== $return_code ) {
-        Logger::error( "Missing {$exec} on the system." );
-      }
-    }
-    Logger::info( 'Found required executables on system: ' . implode( ', ', $execs ) );
-  }
+	public static function check_executables() {
+		$execs = array( 'git', 'composer', 'hub' );
+		foreach( $execs as $exec ) {
+			exec( 'type ' . escapeshellarg( $exec ), $_, $return_code );
+			if ( 0 !== $return_code ) {
+				Logger::error( "Missing {$exec} on the system." );
+			}
+		}
+		Logger::info( 'Found required executables on system: ' . implode( ', ', $execs ) );
+	}
 
 }

--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace CLU;
+
+class Cloner {
+
+  /**
+   * Clone the repository.
+   *
+   * @param string $repo_url
+   * @return string $repo_local_working_copy
+   */
+  public function cloneRepo( $repo_url ) {
+    // Clone the repository to a working directory.
+    $shorthash = substr( md5( mt_rand() . time() ), 0, 7 );
+    $repo_local_working_copy = sys_get_temp_dir() . '/composer-update-' . $shorthash;
+    $cmd = 'hub clone ' . escapeshellarg( $repo_url ) . ' ' . escapeshellarg( $repo_local_working_copy );
+    Logger::info( $cmd );
+    passthru( $cmd, $return_code );
+    if ( 0 !== $return_code ) {
+      Logger::error( 'Git failed to clone repository.' );
+    }
+    Logger::info( 'Git clone successful.' );
+
+    return $repo_local_working_copy;
+  }
+
+}

--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -4,25 +4,25 @@ namespace CLU;
 
 class Cloner {
 
-  /**
+	/**
    * Clone the repository.
    *
    * @param string $repo_url
    * @return string $repo_local_working_copy
    */
-  public function cloneRepo( $repo_url ) {
-    // Clone the repository to a working directory.
-    $shorthash = substr( md5( mt_rand() . time() ), 0, 7 );
-    $repo_local_working_copy = sys_get_temp_dir() . '/composer-update-' . $shorthash;
-    $cmd = 'hub clone ' . escapeshellarg( $repo_url ) . ' ' . escapeshellarg( $repo_local_working_copy );
-    Logger::info( $cmd );
-    passthru( $cmd, $return_code );
-    if ( 0 !== $return_code ) {
-      Logger::error( 'Git failed to clone repository.' );
-    }
-    Logger::info( 'Git clone successful.' );
+	public function cloneRepo( $repo_url ) {
+		// Clone the repository to a working directory.
+		$shorthash = substr( md5( mt_rand() . time() ), 0, 7 );
+		$repo_local_working_copy = sys_get_temp_dir() . '/composer-update-' . $shorthash;
+		$cmd = 'hub clone ' . escapeshellarg( $repo_url ) . ' ' . escapeshellarg( $repo_local_working_copy );
+		Logger::info( $cmd );
+		passthru( $cmd, $return_code );
+		if ( 0 !== $return_code ) {
+			Logger::error( 'Git failed to clone repository.' );
+		}
+		Logger::info( 'Git clone successful.' );
 
-    return $repo_local_working_copy;
-  }
+		return $repo_local_working_copy;
+	}
 
 }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -32,9 +32,9 @@ class Runner {
 		$existing_PR_branch = $this->checkExisting();
 
 		if ( $existing_PR_branch ) {
-		  Logger::info( "Using existing branch: $existing_PR_branch" );
-		  passthru( 'git fetch' );
-		  passthru( 'git checkout ' . $existing_PR_branch );
+			Logger::info( "Using existing branch: $existing_PR_branch" );
+			passthru( 'git fetch' );
+			passthru( 'git checkout ' . $existing_PR_branch );
 		}
 
 		// Perform an initial install to sanity check the package.

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -189,15 +189,13 @@ EOT;
 		$this->curlGitHub($uri, $data, $auth);
 	}
 
-	public function curlGitHub( $uri, $postData = [], $auth = '' )
-	{
+	public function curlGitHub( $uri, $postData = [], $auth = '' ) {
 		Logger::info( 'Call GitHub API: ' . $uri );
 		$ch = $this->createGitHubPostChannel( $uri, $postData, $auth );
 		return $this->execCurlRequest( $ch, 'GitHub' );
 	}
 
-	protected function createGitHubPostChannel( $uri, $postData = [], $auth = '' )
-	{
+	protected function createGitHubPostChannel( $uri, $postData = [], $auth = '' ) {
 		$url = "https://api.github.com/$uri";
 		$ch = $this->createAuthorizationHeaderCurlChannel( $url, $auth );
 		$this->setCurlChannelPostData( $ch, $postData );
@@ -205,8 +203,7 @@ EOT;
 		return $ch;
 	}
 
-	protected function createAuthorizationHeaderCurlChannel( $url, $auth = '' )
-	{
+	protected function createAuthorizationHeaderCurlChannel( $url, $auth = '' ) {
 		$headers = [
 			'Content-Type: application/json',
 			'User-Agent: pantheon/terminus-build-tools-plugin'
@@ -225,8 +222,7 @@ EOT;
 		return $ch;
 	}
 
-	protected function setCurlChannelPostData( $ch, $postData, $force = false )
-	{
+	protected function setCurlChannelPostData( $ch, $postData, $force = false ) {
 		if ( !empty($postData) || $force ) {
 			$payload = json_encode( $postData );
 			curl_setopt( $ch, CURLOPT_POST, 1 );
@@ -234,8 +230,7 @@ EOT;
 		}
 	}
 
-	public function execCurlRequest( $ch, $service = 'API request' )
-	{
+	public function execCurlRequest( $ch, $service = 'API request' ) {
 		$result = curl_exec($ch);
 		if( curl_errno($ch) )
 		{


### PR DESCRIPTION
If clu is run at a time when there is already an open pull request with Composer updates that have
not yet been merged, then the existing branch will be updated. This prevents the accumulation of
pull requests should the maintainer be slow about merging updates.

Also, refactored to allow calling clu without any parameters, to operate on an existing local working
copy of a project at the current working directory. This is handy for ad-hoc use, and also for use
in a CI server in circumstances where the site to be updated has already been checked out by the CI
server.