### PR TITLE
Use hub pr list

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -172,7 +172,7 @@ EOT;
 	}
 
 	private function checkExisting() {
-		exec('hub issue', $output_lines, $return_code);
+		exec('hub pr list hub pr list --format="%t%n" --state=open', $output_lines, $return_code);
 		if ( 0 !== $return_code ) {
 			Logger::error( 'Unable to check for existing pull requests with hub.' );
 		}

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -172,7 +172,7 @@ EOT;
 	}
 
 	private function checkExisting() {
-		exec('hub pr list hub pr list --format="%t%n" --state=open', $output_lines, $return_code);
+		exec('hub pr list --format="%t%n" --state=open', $output_lines, $return_code);
 		if ( 0 !== $return_code ) {
 			Logger::error( 'Unable to check for existing pull requests with hub.' );
 		}


### PR DESCRIPTION
The logic in`checkExisting` is checking _issues_, not _pull request_, to determine if there is an existing update open.

This is causing the function to return `false` when there are, indeed, open CLU pull request.

Changing to `hub pr list` instead of `hub issue` will sort this out.

`--state=open` ensures we receive only open pull requests.

`--format="%t%n"` sets the output to simple the title of the pull request, which the regex expects.

Example:
```sh
andrewtaylor:example-wordpress-composer/ (limit-clu*) $ hub pr list --format="%t%n" --state=open                                                                            
Update Composer dependencies (2019-05-24-00-02)
BT-14: Bitbucket Pipelines preliminary configuration
Update Composer dependencies (2018-12-06-22-44)
Adds comments on how to include custom plugins/themes in the repo
Update ReadMe
Edits
Use `composer.lock` to generate the `composer-cache` key
WP & phpcs version bump
Bumping WP version to 4.9
Updated readme with a link to the installation
```

`hub pr list` was added in [hub version `2.3.0`](https://github.com/github/hub/releases/tag/v2.3.0), the same time `hub issue` was introduced so this won't be a breaking change due to hub versions as the current CLU implementation requires at least `2.3.0` as well.

Closes #1.