### PR TITLE
GitLab repository support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,46 @@ Run composer-lock-updater in your CI system for bot-powered `composer.lock` pull
 
 When you run `clu`, it:
 
-1. Clones a given GitHub repository to a working `/tmp/` directory.
+1. Clones a given GitHub or GitLab repository to a working `/tmp/` directory.
 2. Runs `composer update` within the working directory.
 3. Submits a pull request if changes are detected to a tracked `composer.lock` file.
 
 Et voila! Now your dependencies are no longer six months out of date.
 
-[Use with Travis CI](#use-with-travis-ci) | [Run locally](#run-locally)
+composer-lock-updater is different than [dependabot](https://dependabot.com/) in that it bundles all of your updates into one pull request, instead of creating separate pull requests for each dependency.
 
-## Use with Travis CI
+[Installing](#installing) | [Using](#using) | [Integrate with Travis CI](#use-with-travis-ci)
+
+## Installing
+
+composer-lock-updater is a PHP library that can be installed with Composer:
+
+    composer global require danielbachhuber/composer-lock-updater
+
+composer-lock-updater depends on `composer` and `git` being available on the system. For use with GitHub, also install the official [`hub`](https://github.com/github/hub) CLI tool. For use with GitLab, you can use the unofficial [`lab`](https://github.com/zaquestion/lab) CLI tool that emulates `hub`.
+
+Both `hub` and `lab` will need to be authenticated with their respective services in order to create the pull/merge requests.
+
+## Using
+
+Run composer-lock-updater within an existing GitHub repository with:
+
+    clu
+
+composer-lock-updater defaults to using `git config --get remote.origin.url`. If you'd like to specify a different value, either pass the repository URL as the first positional argument or define a `CLU_GIT_URL` environment variable.
+
+To use composer-lock-updater with a GitLab repository, use:
+
+    clu --provider=gitlab
+
+composer-lock-updater also supports the following environment variables to modify its behavior:
+
+* `CLU_COMPOSER_INSTALL_ARGS`: Arguments passed to `composer install`; defaults to `--no-dev --no-interaction`.
+* `CLU_COMPOSER_UPDATE_ARGS`: Arguments passed to `composer update`; defaults to `--no-progress --no-dev --no-interaction`.
+* `CLU_GIT_NAME`: Name used for Git commits; defaults to 'composer-lock-update'.
+* `CLU_GIT_EMAIL`: Email used for Git commits; defaults to 'composer-lock-update@localhost'.
+
+## Integrate with Travis CI
 
 This wouldn't be very useful if it didn't run automatically for you.
 
@@ -38,6 +69,8 @@ To configure composer-lock-updater to run on Travis master branch builds, add th
         composer global require danielbachhuber/composer-lock-updater
         ###
         # Install hub for creating GitHub pull requests
+        #
+        # You could also replace this with lab to create GitLab merge requests.
         ###
         wget -O hub.tgz https://github.com/github/hub/releases/download/v2.2.9/hub-linux-amd64-2.2.9.tgz
         tar -zxvf hub.tgz
@@ -73,17 +106,3 @@ Lastly, because of the `CLU_RUN` environment variable, composer-lock-updater is 
           env: WP_VERSION=latest PHP_APCU=enabled
 
 Because composer-lock-updater is running on the `after_script` step, make sure to verify it's working correctly, because it won't fail your build if misconfigured.
-
-## Run locally
-
-Before you use composer-lock-updater locally, ensure the `composer`, `git`, and [`hub`](https://github.com/github/hub) executables are present on the filesystem. The current user will need to be authenticated with GitHub (both for push and creating pull requests).
-
-Install composer-lock-updater with:
-
-    composer global require danielbachhuber/composer-lock-updater
-
-Then, update your `composer.lock` file with:
-
-    clu <git-url>
-
-The script provides sufficiently verbose output for debugging purposes.

--- a/bin/clu
+++ b/bin/clu
@@ -47,5 +47,5 @@ if ( ! $repo_local_working_copy ) {
 	$repo_local_working_copy = $cloner->cloneRepo( $repo_url );
 }
 
-$runner = new CLU\Runner( $repo_url );
+$runner = new CLU\Runner( $repo_url, $provider );
 $runner->start( $repo_local_working_copy, $opts );

--- a/bin/clu
+++ b/bin/clu
@@ -10,11 +10,20 @@ if ( file_exists( $path = __DIR__ . '/../vendor/autoload.php' )
 	throw new \Exception('Could not locate autoload.php');
 }
 
-\CLU\Checker::check_executables();
-
 // Simple argv parsing
 $optind = null;
-$opts = getopt('', ['security-only'], $optind);
+$opts = getopt('', ['provider::','security-only'], $optind);
+if ( isset( $opts['provider'] ) ) {
+	if ( ! in_array( $opts['provider'], [ 'github', 'gitlab' ], true ) ) {
+		CLU\Logger::error( "--[provider]=<provider> must be 'github' or 'gitlab'" );
+	}
+	$provider = $opts['provider'];
+} else {
+	$provider = 'github';
+}
+
+\CLU\Checker::check_executables( $provider );
+
 $pos_args = array_slice($argv, $optind);
 
 $repo_url = isset($pos_args[0]) ? $pos_args[0] : '';

--- a/src/Checker.php
+++ b/src/Checker.php
@@ -5,10 +5,18 @@ namespace CLU;
 class Checker {
 
 	/**
-	 * Check that Git, Composer, and Hub are available on the filesystem.
+	 * Check that Git, Composer, and Hub or Lab are available on the filesystem.
 	 */
-	public static function check_executables() {
-		$execs = array( 'git', 'composer', 'hub' );
+	public static function check_executables( $provider ) {
+		$execs = [
+			'git',
+			'composer',
+		];
+		if ( 'github' === $provider ) {
+			$execs[] = 'hub';
+		} elseif ( 'gitlab' === $provider ) {
+			$execs[] = 'lab';
+		}
 		foreach( $execs as $exec ) {
 			exec( 'type ' . escapeshellarg( $exec ), $_, $return_code );
 			if ( 0 !== $return_code ) {

--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -14,8 +14,8 @@ class Cloner {
 		// Clone the repository to a working directory.
 		$shorthash = substr( md5( mt_rand() . time() ), 0, 7 );
 		$repo_local_working_copy = sys_get_temp_dir() . '/composer-update-' . $shorthash;
-		$cmd = 'hub clone ' . escapeshellarg( $repo_url ) . ' ' . escapeshellarg( $repo_local_working_copy );
-		$cmd_to_log = 'hub clone [REDACTED] $repo_local_working_copy';
+		$cmd = 'git clone ' . escapeshellarg( $repo_url ) . ' ' . escapeshellarg( $repo_local_working_copy );
+		$cmd_to_log = 'git clone [REDACTED] $repo_local_working_copy';
 		Logger::info( $cmd_to_log );
 		passthru( $cmd, $return_code );
 		if ( 0 !== $return_code ) {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -155,7 +155,7 @@ EOT;
 			Logger::error( 'Failed to push changes to origin.' );
 		}
 
-		if ( $existing_PR_branch ) {
+		if ( $existing_PR_branch && $this->isGitLab() ) {
 			// Add comment to existing PR with $message
 			$commitSha = exec( 'git rev-parse HEAD', $output_lines, $return_code);
 			$this->addCommitComment( $message, $this->project(), $commitSha );


### PR DESCRIPTION
Continuation of #17

Introduces a new `--provider=<provider>` argument to create merge requests against a GitLab repository, instead of GitHub pull requests. Also updates `README.md` for greater clarity and to document GitLab support.

Tested with https://gitlab.com/danielbachhuber/clu-test/merge_requests/1 and https://github.com/danielbachhuber/clu-test/pull/1

One known issue is that `--provider=gitlab` doesn't yet support updating comments for existing pull requests. It doesn't look like `lab` has direct GitLab API access. We could explore this with #20.