### PR TITLE
Extend support to arbitrary cli providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run composer-lock-updater in your CI system for bot-powered `composer.lock` pull
 
 When you run `clu`, it:
 
-1. Clones a given GitHub or GitLab repository to a working `/tmp/` directory.
+1. Clones a given git repository to a working `/tmp/` directory.
 2. Runs `composer update` within the working directory.
 3. Submits a pull request if changes are detected to a tracked `composer.lock` file.
 
@@ -26,6 +26,23 @@ composer-lock-updater is a PHP library that can be installed with Composer:
 composer-lock-updater depends on `composer` and `git` being available on the system. For use with GitHub, also install the official [`hub`](https://github.com/github/hub) CLI tool. For use with GitLab, you can use the unofficial [`lab`](https://github.com/zaquestion/lab) CLI tool that emulates `hub`.
 
 Both `hub` and `lab` will need to be authenticated with their respective services in order to create the pull/merge requests.
+
+#### Support for other providers
+Copy [clu-config.dist.json](clu-config.dist.json) to `$COMPOSER_HOME/clu-config.json` to add support for your git repository provider, or to make adjustments to the pull request commands. For example, to add support for a Bitbucket-Pantheon project using [Terminus Bitbucket Plugin](https://github.com/aaronbauman/terminus-bitbucket-plugin), create the following `clu-config.json`:
+```
+{
+  "providers": {
+    "terminus": {
+      "provider": "terminus",
+      "exec": ["terminus"],
+      "pr_create": "terminus pr-create --title=\"Update Composer dependencies\" --description %s",
+      "pr_list": "terminus pr-list",
+      "pr_close": "terminus pr-close %d",
+      "title_pattern": "%(\\d+)\\s+Update Composer dependencies\\s+clu\\-([0-9-]*)%"
+    }
+  }
+}
+```
 
 ## Using
 

--- a/bin/clu
+++ b/bin/clu
@@ -12,17 +12,19 @@ if ( file_exists( $path = __DIR__ . '/../vendor/autoload.php' )
 
 // Simple argv parsing
 $optind = null;
+$config = \CLU\Checker::get_config();
 $opts = getopt('', ['provider::','security-only'], $optind);
 if ( isset( $opts['provider'] ) ) {
-	if ( ! in_array( $opts['provider'], [ 'github', 'gitlab' ], true ) ) {
-		CLU\Logger::error( "--[provider]=<provider> must be 'github' or 'gitlab'" );
-	}
-	$provider = $opts['provider'];
+  $provider = $opts['provider'];
 } else {
 	$provider = 'github';
 }
 
-\CLU\Checker::check_executables( $provider );
+if ( empty($config->providers[$provider]) ) {
+  CLU\Logger::error( "--[provider]=<provider> must be one of: " . implode(', ', array_keys($config->providers)));
+}
+
+\CLU\Checker::check_executables( $config->providers[$provider] );
 
 $pos_args = array_slice($argv, $optind);
 
@@ -47,5 +49,5 @@ if ( ! $repo_local_working_copy ) {
 	$repo_local_working_copy = $cloner->cloneRepo( $repo_url );
 }
 
-$runner = new CLU\Runner( $repo_url, $provider );
+$runner = new CLU\Runner( $repo_url, $config->providers[$provider]);
 $runner->start( $repo_local_working_copy, $opts );

--- a/clu-config.dist.json
+++ b/clu-config.dist.json
@@ -1,0 +1,21 @@
+{
+  "providers": {
+    "github": {
+      "provider": "github",
+      "exec": ["hub"],
+      "pr_create": "hub pull-request -m %s",
+      "pr_list": "hub pr list --format=\",%i %t%n\" --state=open",
+      "pr_close": "hub api -XPATCH repos/{owner}/{repo}/issues/%d -f state=closed",
+      "title_pattern": "%#([\\d]+) Update Composer dependencies \\(([0-9-]*)\\)%"
+    },
+    "gitlab": {
+      "provider": "gitlab",
+      "exec": ["lab"],
+      "pr_create": "lab mr create -m %s",
+      "pr_list": "lab mr list",
+      "pr_close": "lab mr close %d",
+      "request_type": "merge request",
+      "title_pattern": "%#([\\d]+) Update Composer dependencies \\(([0-9-]*)\\)%"
+    }
+  }
+}

--- a/src/Checker.php
+++ b/src/Checker.php
@@ -7,17 +7,12 @@ class Checker {
 	/**
 	 * Check that Git, Composer, and Hub or Lab are available on the filesystem.
 	 */
-	public static function check_executables( $provider ) {
-		$execs = [
+	public static function check_executables( \stdClass $provider ) {
+		$execs = array_merge([
 			'git',
 			'composer',
 			'tee',
-		];
-		if ( 'github' === $provider ) {
-			$execs[] = 'hub';
-		} elseif ( 'gitlab' === $provider ) {
-			$execs[] = 'lab';
-		}
+		], $provider->exec);
 		foreach( $execs as $exec ) {
 			exec( 'type ' . escapeshellarg( $exec ), $_, $return_code );
 			if ( 0 !== $return_code ) {
@@ -27,4 +22,20 @@ class Checker {
 		Logger::info( 'Found required executables on system: ' . implode( ', ', $execs ) );
 	}
 
+	public static function get_config() {
+		$defaults = json_decode(file_get_contents(__DIR__ . '/../clu-config.dist.json'));
+		$defaults->providers = get_object_vars($defaults->providers);
+		if (file_exists($path = getenv('COMPOSER_HOME') . '/clu-config.json')
+			|| file_exists($path = getcwd() . '/clu-config.json')
+			){
+			$config = json_decode(file_get_contents($path));
+			if ($error = json_last_error()) {
+				return $defaults;
+			}
+			if (!empty($config->providers)) {
+				$defaults->providers = array_merge($defaults->providers, get_object_vars($config->providers));
+			}
+		}
+		return $defaults;
+	}
 }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -174,7 +174,7 @@ EOT;
 		if ( ! $number ) {
 			Logger::error( sprintf( 'Unable to find existing %s number', $this->getRequestType() ) );
 		}
-		$cmd = $this->provider->pr_close;
+		$cmd = sprintf( $this->provider->pr_close, $number );
 		exec($cmd, $output_lines, $return_code);
 		if ( 0 !== $return_code ) {
 			Logger::error( sprintf( 'Unable to close existing %s #%d: %s', $this->getRequestType(), $number, implode( PHP_EOL, $output_lines ) ) );


### PR DESCRIPTION
In this PR:
Move references to `hub` and `lab` out of code and into a config yml.
Read `$COMPOSER_HOME/clu-config.json` to allow use of arbitrary command providers.

In combination with https://github.com/aaronbauman/terminus-bitbucket-plugin this will allow me to use `clu` for Bitbucket.

Also opens the door to support any other Bitbucket or other provider clients.

I'm not sure the config yml is the best way to store and read this config, nor whether the various paramaters make the most sense. Would welcome some feedback, thanks for your consideration.