### PR TITLE
no-ansi for security-checker

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -203,7 +203,7 @@ EOT;
 			return '';
 		}
 
-		exec( 'security-checker.phar security:check ' . $composerLockPath, $output, $is_vulnerable );
+		exec( 'security-checker.phar security:check --no-ansi ' . $composerLockPath, $output, $is_vulnerable );
 		return "\n\n" . implode("\n", $output);
 	}
 


### PR DESCRIPTION
A little nicer output in some situations.

```
Symfony Security Check Report
=============================

No packages have known vulnerabilities.
```

instead of:

```
[33mSymfony Security Check Report[0m
[33m=============================[0m

[37;42mNo packages have known vulnerabilities.[0m
```