### PR TITLE
Fixes #39 - Properly return composer exit code

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -253,13 +253,14 @@ EOT;
 	 */
 	private function runComposerUpdate() {
 		$args = getenv( 'CLU_COMPOSER_UPDATE_ARGS' ) ? : '--no-progress --no-dev --no-interaction';
-		$cmd  = 'composer update ' . $args . ' 2>&1 | tee vendor/update.log';
+		$cmd  = 'composer update ' . $args . ' 2>&1';
 		Logger::info( $cmd );
 		exec( $cmd, $output, $return_code );
+		$output = implode( PHP_EOL, $output );
+		file_put_contents('vendor/update.log', $output);
 		if ( 0 !== $return_code ) {
 			Logger::error( 'Composer failed to update dependencies.' );
 		}
-		$output = implode( PHP_EOL, $output );
 		Logger::info( $output );
 		return $output;
 	}


### PR DESCRIPTION
Instead of writing the log file in the shell, the PR moves writing vendor/update.log to PHP and allows the return value of composer to be used.